### PR TITLE
router querystrings

### DIFF
--- a/client/src/components/beers/beer-list.js
+++ b/client/src/components/beers/beer-list.js
@@ -72,11 +72,12 @@ class BeerListItem extends React.Component {
   }
 }
 
-function pushFilterQuery(evt){
+// Update the ?q=foo value in the current url.
+// Uses replace so it doesn't create an extra history state.
+function updatePathQueryString(evt) {
   replaceQueryParams({
     q: evt.target.value,
   });
-  console.log('pushed');
 }
 
 // todo - use the react compose branch thing to handle sync.fetching
@@ -120,7 +121,6 @@ class BeerList extends React.Component {
     return (
       <div>
         { sync.fetching ? <Loader /> : (
-
           <section className="beer-list-view">
             <header className="page-header">
               <h1 className="page-title">Beers.</h1>
@@ -135,7 +135,7 @@ class BeerList extends React.Component {
               <input
                 type="search"
                 onChange={this.setFilterQuery}
-                onBlur={pushFilterQuery}
+                onBlur={updatePathQueryString}
                 value={filterQuery}
                 placeholder="search..."
               />

--- a/client/src/components/beers/beer-list.js
+++ b/client/src/components/beers/beer-list.js
@@ -11,6 +11,7 @@ import { Container } from 'flux/utils';
 import { fetchBeers, voteForBeer, unvoteForBeer, showAddBeer } from '../../actions/beers';
 import beersStore from '../../stores/beers';
 import * as propTypes from '../../proptypes/';
+import { replaceQueryParams } from '../router';
 
 import Loader from '../loader/';
 import BeerEdit from './beer-edit';
@@ -71,6 +72,12 @@ class BeerListItem extends React.Component {
   }
 }
 
+function pushFilterQuery(evt){
+  replaceQueryParams({
+    q: evt.target.value,
+  });
+  console.log('pushed');
+}
 
 // todo - use the react compose branch thing to handle sync.fetching
 class BeerList extends React.Component {
@@ -86,6 +93,12 @@ class BeerList extends React.Component {
     this.setFilterQuery = this.setFilterQuery.bind(this);
   }
 
+  componentWillReceiveProps(props) {
+    this.setState({
+      filterQuery: (props.queryParams && props.queryParams.q) || '',
+    });
+  }
+
   setFilterQuery(evt) {
     this.setState({
       filterQuery: evt.target.value,
@@ -94,7 +107,6 @@ class BeerList extends React.Component {
 
   render() {
     const { beers, sync, create, profile } = this.props;
-
     const { filterQuery } = this.state;
 
     const filteredBeers = !filterQuery ? beers : beers.filter((beer) => {
@@ -123,6 +135,7 @@ class BeerList extends React.Component {
               <input
                 type="search"
                 onChange={this.setFilterQuery}
+                onBlur={pushFilterQuery}
                 value={filterQuery}
                 placeholder="search..."
               />

--- a/client/src/components/router.js
+++ b/client/src/components/router.js
@@ -129,7 +129,6 @@ function getQueryParams(pathWithParams) {
   return queryParamsToObject(match[0].slice(1));
 }
 
-
 export function replaceQueryParams(params) {
   const path = document.location.hash;
   const currentQueryParams = getQueryParams(document.location.hash);
@@ -140,9 +139,6 @@ export function replaceQueryParams(params) {
   };
 
   const stringifiedQueryParams = objectToQueryParams(newQueryParams);
-
-  debugger;
-
   history.replaceState({}, null, path.replace(/\?.*/, `?${stringifiedQueryParams}`));
 }
 

--- a/client/src/components/router.js
+++ b/client/src/components/router.js
@@ -97,12 +97,22 @@ const routes = {
 routes.defaultRoute = routes['/kegs'];
 
 
-// converts ! literals to capture groups for capturing params
+/**
+ * Converts ! literals into matching groups
+ * for parsing routes.
+ * @param  {String} route
+ * @return {RegExp}
+ */
 function routeToRegex(route) {
   return new RegExp(route.replace(/!/g, '([\\w|\\-]+)'));
 }
 
-// foo=bar&bar=qux => object
+/**
+ * Convert a string of foo=bar&bar=qux
+ * to an object of key-pairs.
+ * @param  {String} str
+ * @return {Object}
+ */
 export function queryParamsToObject(str) {
   const pairs = str.split('&');
 
@@ -113,15 +123,22 @@ export function queryParamsToObject(str) {
   }, {});
 }
 
-// object => foo=bar&bar=qux
+/**
+ * Create a query string of foo=bar&bar=qux
+ * from an object. Doesn't prefix with a ? though.
+ * @param  {Object} obj
+ * @return {String}
+ */
 export function objectToQueryParams(obj) {
   const pairs = Object.keys(obj).map(key => `${key}=${obj[key]}`);
   return pairs.join('&');
 }
 
-// return the query params as an object
-// pass in a path as a string, we can't use location.search
-// because we're using hash urls.
+/**
+ * Parse a path to return the query params as an object
+ * @param  {String} pathWithParams
+ * @return {Object}
+ */
 function getQueryParams(pathWithParams) {
   const match = pathWithParams.match(/\?.*/);
   if (!match) return {};
@@ -129,6 +146,12 @@ function getQueryParams(pathWithParams) {
   return queryParamsToObject(match[0].slice(1));
 }
 
+
+/**
+ * Use history.replace to switch current query params
+ * for new ones.
+ * @param  {Object} params key-value pairs to add/replace
+ */
 export function replaceQueryParams(params) {
   const path = document.location.hash;
   const currentQueryParams = getQueryParams(document.location.hash);


### PR DESCRIPTION
- Lets the dodgy home-baked router pass querystrings like `?foo=bar` down to the components. 
- the beer list view now passes `?q=foobar` into the search box
- beer list view updates the `?q=foobar` in your location when you blur the search box